### PR TITLE
generalize blobstore (part 1)

### DIFF
--- a/datasource/src/main/scala/quasar/blobstore/Converter.scala
+++ b/datasource/src/main/scala/quasar/blobstore/Converter.scala
@@ -16,16 +16,6 @@
 
 package quasar.blobstore
 
-import slamdata.Predef._
-
-import fs2.Stream
-
-object services {
-  trait StatusService[F[_], S] {
-    def status: F[S]
-  }
-
-  trait GetService[F[_], P] {
-    def get(path: P): Stream[F, Byte]
-  }
+trait Converter[F[_], A, B] {
+  def convert(a: A): F[B]
 }

--- a/datasource/src/main/scala/quasar/blobstore/azure/AzureGetService.scala
+++ b/datasource/src/main/scala/quasar/blobstore/azure/AzureGetService.scala
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2014–2018 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package quasar.blobstore.azure
+
+import slamdata.Predef._
+import quasar.blobstore.{Converter, ops}
+import quasar.blobstore.azure.requests.DownloadArgs
+import quasar.blobstore.services.GetService
+
+import cats.effect.ConcurrentEffect
+import cats.syntax.applicative._
+import cats.syntax.flatMap._
+import com.microsoft.azure.storage.blob._
+import com.microsoft.rest.v2.Context
+import fs2.Stream
+
+class AzureGetService[F[_]: ConcurrentEffect, P](
+    args: BlobURL => DownloadArgs,
+    reliableDownloadOptions: ReliableDownloadOptions,
+    maxQueueSize: MaxQueueSize,
+    errorHandler: P => Throwable => Stream[F, Byte])(
+    implicit CP: Converter[F, P, BlobURL])
+  extends GetService[F, P] {
+
+  override def get(path: P): Stream[F, Byte] =
+    ops.service[F, P, DownloadArgs, DownloadResponse, Stream[F, Byte], Stream[F, Byte]](
+      CP.convert(_) >>= (args(_).pure[F]),
+      requests.downloadRequest[F],
+      handlers.toByteStream(reliableDownloadOptions, maxQueueSize),
+      Stream.force(_).handleErrorWith(errorHandler(path))
+    ).apply(path)
+
+}
+
+object AzureGetService {
+  def apply[F[_]: ConcurrentEffect, P: Converter[F, ?, BlobURL]](
+    maxQueueSize: MaxQueueSize,
+    errorHandler: P => Throwable => Stream[F, Byte])
+      : AzureGetService[F, P] =
+    new AzureGetService[F, P](
+      url => DownloadArgs(url, BlobRange.DEFAULT, BlobAccessConditions.NONE, false, Context.NONE),
+      new ReliableDownloadOptions,
+      maxQueueSize,
+      errorHandler)
+}

--- a/datasource/src/main/scala/quasar/blobstore/azure/AzureListService.scala
+++ b/datasource/src/main/scala/quasar/blobstore/azure/AzureListService.scala
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2014–2018 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package quasar.blobstore.azure
+
+import slamdata.Predef._
+import quasar.blobstore.azure.requests.ListBlobHierarchyArgs
+import quasar.blobstore.{Converter, ops}
+import quasar.blobstore.services.ListService
+
+import cats.effect.Async
+import cats.syntax.functor._
+import com.microsoft.azure.storage.blob.{ContainerURL, ListBlobsOptions}
+import com.microsoft.azure.storage.blob.models.ContainerListBlobHierarchySegmentResponse
+import com.microsoft.rest.v2.Context
+import fs2.Stream
+
+class AzureListService[F[_]: Async, P, R](
+    mkArgs: ListBlobsOptions => ListBlobHierarchyArgs,
+    handler: F[Option[Stream[F, R]]] => F[Option[Stream[F, R]]])(
+    implicit CP: Converter[F, P, ListBlobsOptions], CR: Converter[F, (ContainerListBlobHierarchySegmentResponse, P), Option[Stream[F, R]]])
+  extends ListService[F, P, R] {
+
+  override def list(path: P): F[Option[Stream[F, R]]] =
+    ops.service[F, P, ListBlobHierarchyArgs, ContainerListBlobHierarchySegmentResponse, Option[Stream[F, R]], F[Option[Stream[F, R]]]](
+      CP.convert(_).map(mkArgs),
+      requests.listRequest[F],
+      res => CR.convert((res, path)),
+      handler
+    ).apply(path)
+}
+
+object AzureListService {
+  def apply[F[_]: Async, P: Converter[F, ?, ListBlobsOptions], R: λ[A => Converter[F, (ContainerListBlobHierarchySegmentResponse, P), Option[Stream[F, A]]]]](
+    containerURL: ContainerURL,
+    handler: F[Option[Stream[F, R]]] => F[Option[Stream[F, R]]]): AzureListService[F, P, R] =
+    new AzureListService[F, P, R](
+      ListBlobHierarchyArgs(containerURL, None, "/", _, Context.NONE),
+      handler
+    )
+}

--- a/datasource/src/main/scala/quasar/blobstore/azure/AzurePropsService.scala
+++ b/datasource/src/main/scala/quasar/blobstore/azure/AzurePropsService.scala
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2014–2018 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package quasar.blobstore.azure
+
+import quasar.blobstore.azure.requests.BlobPropsArgs
+import quasar.blobstore.{Converter, ops}
+import quasar.blobstore.services.PropsService
+
+import cats.effect.Async
+import cats.syntax.functor._
+import com.microsoft.azure.storage.blob.{BlobAccessConditions, BlobURL}
+import com.microsoft.azure.storage.blob.models.BlobGetPropertiesResponse
+import com.microsoft.rest.v2.Context
+
+class AzurePropsService[F[_]: Async, P, R](
+    mkArgs: BlobURL => BlobPropsArgs,
+    handler: F[R] => F[R])(
+    implicit CP: Converter[F, P, BlobURL], CR: Converter[F, BlobGetPropertiesResponse, R])
+  extends PropsService[F, P, R] {
+
+  override def props(path: P): F[R] =
+    ops.service[F, P, BlobPropsArgs, BlobGetPropertiesResponse, R, F[R]](
+      CP.convert(_).map(mkArgs),
+      requests.blobPropsRequest[F],
+      CR.convert(_),
+      handler
+    ).apply(path)
+
+}
+
+object AzurePropsService {
+  def apply[F[_]: Async, P: Converter[F, ?, BlobURL], R: Converter[F, BlobGetPropertiesResponse, ?]](handler: F[R] => F[R]): AzurePropsService[F, P, R] =
+    new AzurePropsService[F, P, R](
+      BlobPropsArgs(_, BlobAccessConditions.NONE, Context.NONE),
+      handler)
+}

--- a/datasource/src/main/scala/quasar/blobstore/azure/AzureStatusService.scala
+++ b/datasource/src/main/scala/quasar/blobstore/azure/AzureStatusService.scala
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2014–2018 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package quasar.blobstore.azure
+
+import slamdata.Predef.Unit
+import quasar.blobstore.{BlobstoreStatus, ops}
+import quasar.blobstore.azure.requests.ContainerPropsArgs
+import quasar.blobstore.services.StatusService
+
+import cats.effect.Async
+import cats.syntax.applicative._
+import com.microsoft.azure.storage.blob.ContainerURL
+import com.microsoft.azure.storage.blob.models.{ContainerGetPropertiesResponse, LeaseAccessConditions}
+import com.microsoft.rest.v2.Context
+
+class AzureStatusService[F[_]: Async](args: ContainerPropsArgs) extends StatusService[F, BlobstoreStatus] {
+  override def status: F[BlobstoreStatus] =
+    ops.service[F, Unit, ContainerPropsArgs, ContainerGetPropertiesResponse, BlobstoreStatus, F[BlobstoreStatus]](
+      _ => args.pure[F],
+      requests.containerPropsRequest[F],
+      _ => BlobstoreStatus.ok().pure[F],
+      handlers.recoverToBlobstoreStatus[F, BlobstoreStatus]
+    ).apply(())
+
+}
+
+object AzureStatusService {
+  def apply[F[_]: Async](containerURL: ContainerURL): AzureStatusService[F] =
+    new AzureStatusService[F](ContainerPropsArgs(containerURL, new LeaseAccessConditions, Context.NONE))
+}

--- a/datasource/src/main/scala/quasar/blobstore/azure/handlers.scala
+++ b/datasource/src/main/scala/quasar/blobstore/azure/handlers.scala
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2014–2018 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package quasar.blobstore.azure
+
+import slamdata.Predef._
+import quasar.blobstore.BlobstoreStatus
+
+import scala.util.control.NonFatal
+
+import cats.ApplicativeError
+import cats.effect.ConcurrentEffect
+import cats.instances.int._
+import cats.syntax.applicativeError._
+import cats.syntax.eq._
+import cats.syntax.functor._
+import com.microsoft.azure.storage.blob.{DownloadResponse, ReliableDownloadOptions, StorageException}
+import fs2.{Chunk, Stream}
+
+object handlers {
+
+  def recoverToBlobstoreStatus[F[_]: ApplicativeError[?[_], Throwable], A](fa: F[A]): F[BlobstoreStatus] =
+    fa.map(_ => BlobstoreStatus.ok()).recover {
+      case ex: StorageException if ex.statusCode === 403 => BlobstoreStatus.noAccess()
+      case ex: StorageException if ex.statusCode === 404 => BlobstoreStatus.notFound()
+      case ex: StorageException => BlobstoreStatus.notOk(ex.message())
+      case NonFatal(t) => BlobstoreStatus.notOk(t.getMessage)
+    }
+
+  def toByteStream[F[_]: ConcurrentEffect](reliableDownloadOptions: ReliableDownloadOptions, maxQueueSize: MaxQueueSize)(r: DownloadResponse): F[Stream[F, Byte]] =
+    ConcurrentEffect[F].delay {
+      for {
+        buf <- rx.flowableToStream(r.body(reliableDownloadOptions), maxQueueSize.value)
+        b <- Stream.chunk(Chunk.byteBuffer(buf))
+      } yield b
+    }
+
+}

--- a/datasource/src/main/scala/quasar/blobstore/azure/requests.scala
+++ b/datasource/src/main/scala/quasar/blobstore/azure/requests.scala
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2014–2018 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package quasar.blobstore.azure
+
+import slamdata.Predef._
+
+import cats.effect.{Async, Sync}
+import cats.syntax.flatMap._
+import com.microsoft.azure.storage.blob._
+import com.microsoft.azure.storage.blob.models._
+import com.microsoft.rest.v2.Context
+
+object requests {
+
+  final case class ListBlobHierarchyArgs(containerURL: ContainerURL, marker: Option[String], delimiter: String, options: ListBlobsOptions, context: Context)
+
+  @SuppressWarnings(Array("org.wartremover.warts.Null"))
+  def listRequest[F[_]: Async](args: ListBlobHierarchyArgs): F[ContainerListBlobHierarchySegmentResponse] =
+    Sync[F].delay(args.containerURL.listBlobsHierarchySegment(args.marker.orNull, args.delimiter, args.options, args.context)) >>=
+      rx.singleToAsync[F, ContainerListBlobHierarchySegmentResponse]
+
+  final case class BlobPropsArgs(blobURL: BlobURL, blobAccessConditions: BlobAccessConditions, context: Context)
+
+  def blobPropsRequest[F[_]: Async](args: BlobPropsArgs): F[BlobGetPropertiesResponse] =
+    Sync[F].delay(args.blobURL.getProperties(args.blobAccessConditions, args.context)) >>=
+      rx.singleToAsync[F, BlobGetPropertiesResponse]
+
+  final case class DownloadArgs(blobURL: BlobURL, blobRange: BlobRange, blobAccessConditions: BlobAccessConditions, rangeGetContentMD5: Boolean, context: Context)
+
+  def downloadRequest[F[_]: Async](args: DownloadArgs): F[DownloadResponse] =
+    Sync[F].delay(args.blobURL.download(args.blobRange, args.blobAccessConditions, args.rangeGetContentMD5, args.context)) >>=
+      rx.singleToAsync[F, DownloadResponse]
+
+  final case class ContainerPropsArgs(containerURL: ContainerURL, leaseAccessConditions: LeaseAccessConditions, context: Context)
+
+  def containerPropsRequest[F[_]: Async](args: ContainerPropsArgs): F[ContainerGetPropertiesResponse] =
+    Sync[F].delay(args.containerURL.getProperties(args.leaseAccessConditions, args.context)) >>=
+      rx.singleToAsync[F, ContainerGetPropertiesResponse]
+
+}

--- a/datasource/src/main/scala/quasar/blobstore/ops.scala
+++ b/datasource/src/main/scala/quasar/blobstore/ops.scala
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2014–2018 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package quasar.blobstore
+
+import cats.Monad
+import cats.syntax.flatMap._
+
+object ops {
+
+  def service[F[_]: Monad, A, Req, Res, B, C]
+      (reqEncoder: A => F[Req], request: Req => F[Res], resDecoder: Res => F[B], handler: F[B] => C)
+      : A => C = { a: A =>
+    handler(reqEncoder(a) >>= request >>= resDecoder)
+  }
+
+}

--- a/datasource/src/main/scala/quasar/blobstore/services.scala
+++ b/datasource/src/main/scala/quasar/blobstore/services.scala
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2014–2018 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package quasar.blobstore
+
+object services {
+
+  trait StatusService[F[_], S] {
+    def status: F[S]
+  }
+}

--- a/datasource/src/main/scala/quasar/blobstore/services.scala
+++ b/datasource/src/main/scala/quasar/blobstore/services.scala
@@ -21,6 +21,7 @@ import slamdata.Predef._
 import fs2.Stream
 
 object services {
+
   trait StatusService[F[_], S] {
     def status: F[S]
   }
@@ -31,5 +32,9 @@ object services {
 
   trait PropsService[F[_], P, R] {
     def props(path: P): F[R]
+  }
+
+  trait ListService[F[_], P, R] {
+    def list(path: P): F[Option[Stream[F, R]]]
   }
 }

--- a/datasource/src/main/scala/quasar/blobstore/services.scala
+++ b/datasource/src/main/scala/quasar/blobstore/services.scala
@@ -28,4 +28,8 @@ object services {
   trait GetService[F[_], P] {
     def get(path: P): Stream[F, Byte]
   }
+
+  trait PropsService[F[_], P, R] {
+    def props(path: P): F[R]
+  }
 }


### PR DESCRIPTION
In this PR:
* defined interfaces in `services`: `StatusService`, `GetService`, `PropsService` and `ListService`
* implemented these interfaces for Azure
* used these implementations in `AzureBlobstore`

In part 2, further strip down `AzureBlobstore`:
* get rid of special handling of paths ending in `/` (which were translated to list of resource names ending with `""` but this is fixed now)
* implement generic `pathConverters` and `responseConverters` in `quasar.blobstore.azure` (and use these as much as possible in `AzureBlobstore` instead of the specific implicits in `AzureBlobstore`)